### PR TITLE
Set default value for config attribute of swiftformat_format

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ load(
 
 swiftformat_pkg(
     name = "format",
-    config = "//:.swiftformat",
 )
 ```
 

--- a/doc/rules_and_macros_overview.md
+++ b/doc/rules_and_macros_overview.md
@@ -31,7 +31,7 @@ Formats the Swift source files using `nicklockwood/SwiftFormat`.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="swiftformat_format-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="swiftformat_format-config"></a>config |  A swiftformat config file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="swiftformat_format-config"></a>config |  A swiftformat config file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | @//:.swiftformat |
 | <a id="swiftformat_format-output_suffix"></a>output_suffix |  The suffix to add to the output filename.   | String | optional | "_formatted" |
 | <a id="swiftformat_format-srcs"></a>srcs |  The Swift source files to format.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 | <a id="swiftformat_format-swift_version"></a>swift_version |  The Swift version to be used by <code>swiftformat</code>. You probably want to add this to your config file instead of adding it here.   | String | optional | "" |

--- a/examples/simple/BUILD.bazel
+++ b/examples/simple/BUILD.bazel
@@ -39,6 +39,5 @@ swiftformat_update_all(
 # test that the formatted files are in the workspace directory and copies
 # the formatted files to the workspace directory.
 swiftformat_pkg(
-    name = "format",
-    config = "//:.swiftformat",
+    name = "swiftformat",
 )

--- a/examples/simple/Foo/BUILD.bazel
+++ b/examples/simple/Foo/BUILD.bazel
@@ -9,6 +9,5 @@ swift_library(
 )
 
 swiftformat_pkg(
-    name = "format",
-    config = "//:.swiftformat",
+    name = "swiftformat",
 )

--- a/examples/swift_rule_helpers/Sources/App/BUILD.bazel
+++ b/examples/swift_rule_helpers/Sources/App/BUILD.bazel
@@ -7,7 +7,6 @@ load(
 swiftformat_binary(
     name = "simple",
     srcs = ["main.swift"],
-    swiftformat_config = "//:.swiftformat",
     visibility = ["//:__subpackages__"],
     deps = [
         "//Sources/Foo",

--- a/examples/swift_rule_helpers/Sources/Foo/BUILD.bazel
+++ b/examples/swift_rule_helpers/Sources/Foo/BUILD.bazel
@@ -7,6 +7,5 @@ swiftformat_library(
     name = "Foo",
     srcs = glob(["*.swift"]),
     module_name = "Foo",
-    swiftformat_config = "//:.swiftformat",
     visibility = ["//:__subpackages__"],
 )

--- a/examples/swift_rule_helpers/Tests/FooTests/MessageTests.swift
+++ b/examples/swift_rule_helpers/Tests/FooTests/MessageTests.swift
@@ -2,9 +2,9 @@
 import XCTest
 
 class MessageTests: XCTestCase {
-    func test_init() throws {
-        let value = "hello"
-        let msg = Messsage(value = value)
-        XCTAssertEqual(msg.value, value)
-    }
+  func test_init() throws {
+    let value = "hello"
+    let msg = Messsage(value = value)
+    XCTAssertEqual(msg.value, value)
+  }
 }

--- a/swiftformat/internal/swiftformat_format.bzl
+++ b/swiftformat/internal/swiftformat_format.bzl
@@ -60,6 +60,7 @@ to your config file instead of adding it here.\
         "config": attr.label(
             allow_single_file = True,
             doc = "A swiftformat config file.",
+            default = "@//:.swiftformat",
         ),
         "output_suffix": attr.string(
             default = "_formatted",


### PR DESCRIPTION
This requires that anyone that uses the rules must have a `.swiftformat` file and it must be exposed as a target at `//:.swiftformat`. This seems reasonable given that anyone that wants to use swiftformat will have a config file with their options set. The standard procedure is to store it at the root of the project.