### PR TITLE
Migrate from `rules_bzlformat`, `rules_updatesrc`, and `bazel_shlib` to `bazel-starlib`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,11 +1,11 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(
-    "@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl",
+    "@cgrindel_bazel_starlib//bzlformat:defs.bzl",
     "bzlformat_missing_pkgs",
     "bzlformat_pkg",
 )
 load(
-    "@cgrindel_rules_updatesrc//updatesrc:updatesrc.bzl",
+    "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
     "updatesrc_update_all",
 )
 load(

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ swiftformat_rules_dependencies()
 # Configure the dependencies for rules_swiftformat
 
 load(
-    "@cgrindel_rules_updatesrc//updatesrc:deps.bzl",
-    "updatesrc_rules_dependencies",
+    "@cgrindel_bazel_starlib//:deps.bzl",
+    "bazel_starlib_dependencies",
 )
 
-updatesrc_rules_dependencies()
+bazel_starlib_dependencies()
 
 load(
     "@cgrindel_rules_spm//spm:deps.bzl",
@@ -76,7 +76,7 @@ following:
 
 ```python
 load(
-    "@cgrindel_rules_updatesrc//updatesrc:updatesrc.bzl",
+    "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
     "updatesrc_update_all",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,20 +8,9 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-load(
-    "@cgrindel_rules_updatesrc//updatesrc:deps.bzl",
-    "updatesrc_rules_dependencies",
-)
+load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
 
-updatesrc_rules_dependencies()
-
-load("@cgrindel_bazel_doc//bazeldoc:deps.bzl", "bazeldoc_dependencies")
-
-bazeldoc_dependencies()
-
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
-bazel_skylib_workspace()
+bazel_starlib_dependencies()
 
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
@@ -48,13 +37,7 @@ load(
 
 swift_rules_extra_dependencies()
 
-load("@cgrindel_rules_bzlformat//bzlformat:deps.bzl", "bzlformat_rules_dependencies")
-
-bzlformat_rules_dependencies()
-
-load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
-
-bazel_starlib_dependencies()
+# MARK: - Buildifier
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
     "@cgrindel_bazel_doc//bazeldoc:bazeldoc.bzl",
     "doc_for_provs",

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
     "@cgrindel_rules_bazel_integration_test//bazel_integration_test:bazel_integration_test.bzl",
     "bazel_integration_test",
@@ -55,7 +55,7 @@ sh_binary(
     ],
     deps = [
         "@bazel_tools//tools/bash/runfiles",
-        "@cgrindel_bazel_shlib//lib:assertions",
+        "@cgrindel_bazel_starlib//shlib/lib:assertions",
     ],
 )
 

--- a/examples/change_update_all_test.sh
+++ b/examples/change_update_all_test.sh
@@ -11,7 +11,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-assertions_sh_location=cgrindel_bazel_shlib/lib/assertions.sh
+assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
 assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"

--- a/examples/exclude_files/BUILD.bazel
+++ b/examples/exclude_files/BUILD.bazel
@@ -1,5 +1,5 @@
 load(
-    "@cgrindel_rules_updatesrc//updatesrc:updatesrc.bzl",
+    "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
     "updatesrc_update_all",
 )
 

--- a/examples/exclude_files/WORKSPACE
+++ b/examples/exclude_files/WORKSPACE
@@ -10,11 +10,11 @@ load("@cgrindel_rules_swiftformat//swiftformat:deps.bzl", "swiftformat_rules_dep
 swiftformat_rules_dependencies()
 
 load(
-    "@cgrindel_rules_updatesrc//updatesrc:deps.bzl",
-    "updatesrc_rules_dependencies",
+    "@cgrindel_bazel_starlib//:deps.bzl",
+    "bazel_starlib_dependencies",
 )
 
-updatesrc_rules_dependencies()
+bazel_starlib_dependencies()
 
 load(
     "@cgrindel_rules_spm//spm:deps.bzl",

--- a/examples/rules_swift_helpers/BUILD.bazel
+++ b/examples/rules_swift_helpers/BUILD.bazel
@@ -1,5 +1,5 @@
 load(
-    "@cgrindel_rules_updatesrc//updatesrc:updatesrc.bzl",
+    "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
     "updatesrc_update_all",
 )
 

--- a/examples/rules_swift_helpers/WORKSPACE
+++ b/examples/rules_swift_helpers/WORKSPACE
@@ -10,11 +10,11 @@ load("@cgrindel_rules_swiftformat//swiftformat:deps.bzl", "swiftformat_rules_dep
 swiftformat_rules_dependencies()
 
 load(
-    "@cgrindel_rules_updatesrc//updatesrc:deps.bzl",
-    "updatesrc_rules_dependencies",
+    "@cgrindel_bazel_starlib//:deps.bzl",
+    "bazel_starlib_dependencies",
 )
 
-updatesrc_rules_dependencies()
+bazel_starlib_dependencies()
 
 load(
     "@cgrindel_rules_spm//spm:deps.bzl",

--- a/examples/simple/BUILD.bazel
+++ b/examples/simple/BUILD.bazel
@@ -4,7 +4,7 @@ load(
     "swiftformat_pkg",
 )
 load(
-    "@cgrindel_rules_updatesrc//updatesrc:updatesrc.bzl",
+    "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
     "updatesrc_update_all",
 )
 

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -10,11 +10,11 @@ load("@cgrindel_rules_swiftformat//swiftformat:deps.bzl", "swiftformat_rules_dep
 swiftformat_rules_dependencies()
 
 load(
-    "@cgrindel_rules_updatesrc//updatesrc:deps.bzl",
-    "updatesrc_rules_dependencies",
+    "@cgrindel_bazel_starlib//:deps.bzl",
+    "bazel_starlib_dependencies",
 )
 
-updatesrc_rules_dependencies()
+bazel_starlib_dependencies()
 
 load(
     "@cgrindel_rules_spm//spm:deps.bzl",

--- a/swiftformat/BUILD.bazel
+++ b/swiftformat/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/swiftformat/deps.bzl
+++ b/swiftformat/deps.bzl
@@ -6,35 +6,17 @@ def swiftformat_rules_dependencies():
     maybe(
         http_archive,
         name = "bazel_skylib",
-        sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
         ],
+        sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
     )
 
     maybe(
-        http_archive,
-        name = "cgrindel_rules_updatesrc",
-        sha256 = "18eb6620ac4684c2bc722b8fe447dfaba76f73d73e2dfcaf837f542379ed9bc3",
-        strip_prefix = "rules_updatesrc-0.1.0",
-        urls = ["https://github.com/cgrindel/rules_updatesrc/archive/v0.1.0.tar.gz"],
-    )
-
-    maybe(
-        http_archive,
-        name = "cgrindel_bazel_doc",
-        sha256 = "3ccc6d205a7f834c5e89adcb4bc5091a9a07a69376107807eb9aea731ce92854",
-        strip_prefix = "bazel-doc-0.1.2",
-        urls = ["https://github.com/cgrindel/bazel-doc/archive/v0.1.2.tar.gz"],
-    )
-
-    maybe(
-        http_archive,
-        name = "cgrindel_rules_bzlformat",
-        sha256 = "44b09ad9c5395760065820676ba6e65efec08ae02c1ce7e2d39d42c5b1e7aec8",
-        strip_prefix = "rules_bzlformat-0.2.1",
-        urls = ["https://github.com/cgrindel/rules_bzlformat/archive/v0.2.1.tar.gz"],
+        native.local_repository,
+        name = "cgrindel_bazel_starlib",
+        path = "/Users/chuck/code/cgrindel/bazel-starlib",
     )
 
     maybe(
@@ -51,12 +33,4 @@ def swiftformat_rules_dependencies():
         sha256 = "50b808269ee09373c099256103c40629db8a66fd884030d7a36cf9a2e8675b75",
         strip_prefix = "rules_bazel_integration_test-0.3.1",
         urls = ["https://github.com/cgrindel/rules_bazel_integration_test/archive/v0.3.1.tar.gz"],
-    )
-
-    maybe(
-        http_archive,
-        name = "cgrindel_bazel_shlib",
-        sha256 = "39c250852fb455e5de18f836c0c339075d6e52ea5ec52a76d62ef9e2eed56337",
-        strip_prefix = "bazel_shlib-0.2.1",
-        urls = ["https://github.com/cgrindel/bazel_shlib/archive/v0.2.1.tar.gz"],
     )

--- a/swiftformat/deps.bzl
+++ b/swiftformat/deps.bzl
@@ -14,9 +14,13 @@ def swiftformat_rules_dependencies():
     )
 
     maybe(
-        native.local_repository,
+        http_archive,
         name = "cgrindel_bazel_starlib",
-        path = "/Users/chuck/code/cgrindel/bazel-starlib",
+        sha256 = "238c05abf31447b93bd15b616c7413c4c719ee7b5e81c1489ca20f02ce628489",
+        strip_prefix = "bazel-starlib-0.2.0",
+        urls = [
+            "http://github.com/cgrindel/bazel-starlib/archive/v0.2.0.tar.gz",
+        ],
     )
 
     maybe(

--- a/swiftformat/internal/BUILD.bazel
+++ b/swiftformat/internal/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//swiftformat:__subpackages__"])
 
@@ -25,7 +25,7 @@ bzl_library(
     deps = [
         ":providers",
         "@bazel_skylib//lib:paths",
-        "@cgrindel_rules_updatesrc//updatesrc",
+        "@cgrindel_bazel_starlib//updatesrc:defs",
     ],
 )
 
@@ -36,7 +36,7 @@ bzl_library(
         ":src_utils",
         ":swiftformat_format",
         "@bazel_skylib//rules:diff_test",
-        "@cgrindel_rules_updatesrc//updatesrc",
+        "@cgrindel_bazel_starlib//updatesrc:defs",
     ],
 )
 

--- a/swiftformat/internal/swiftformat_format.bzl
+++ b/swiftformat/internal/swiftformat_format.bzl
@@ -1,6 +1,6 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
-    "@cgrindel_rules_updatesrc//updatesrc:updatesrc.bzl",
+    "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
     "UpdateSrcsInfo",
     "update_srcs",
 )

--- a/swiftformat/internal/swiftformat_pkg.bzl
+++ b/swiftformat/internal/swiftformat_pkg.bzl
@@ -1,7 +1,7 @@
 load(":src_utils.bzl", "src_utils")
 load(":swiftformat_format.bzl", "swiftformat_format")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
-load("@cgrindel_rules_updatesrc//updatesrc:updatesrc.bzl", "updatesrc_update")
+load("@cgrindel_bazel_starlib//updatesrc:defs.bzl", "updatesrc_update")
 
 """A macro which defines targets that format Swift source files, test that 
 they are formatted and copies them to the workspace directory.

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,6 +1,6 @@
 load(":src_utils_tests.bzl", "src_utils_test_suite")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 


### PR DESCRIPTION
Related to cgrindel/bazel-starlib#44.
