### PR TITLE
Implemented release workflow using `bzlrelease`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build
+name: CI for PR Merge
 
 on:
   pull_request:
@@ -12,17 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Write local.bazelrc File
-      shell: bash
-      run: |
-        cat >local.bazelrc <<EOF
-        common --config=ci
-        EOF
-
-    - name: Output the Bazel Info
-      shell: bash
-      run: |
-        bazelisk info
+    - uses: cgrindel/gha_set_up_bazel@v1
+      with:
+        repo_name: rules_swiftformat
 
     - name: Execute Tests
       shell: bash

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,45 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+      reset_tag:
+        type: boolean
+        default: false
+      base_branch:
+        description: The branch being merged to.
+        type: string
+        default: main
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+
+    steps:
+
+    # Check out your code
+    - uses: actions/checkout@v2
+
+    # Generate a token that has permssions to create a release and create PRs.
+    - uses: tibdex/github-app-token@v1
+      id: generate_token
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+    # Configure the git user for the repository
+    - uses: cgrindel/gha_configure_git_user@v1
+
+    # Create the release
+    - uses: cgrindel/gha_create_release@v1
+      with:
+        release_tag: ${{  github.event.inputs.release_tag }}
+        reset_tag: ${{  github.event.inputs.reset_tag }}
+        base_branch: ${{  github.event.inputs.base_branch }}
+        github_token: ${{ steps.generate_token.outputs.token }}
+ 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ out [the documentation](/doc/) and [the examples](/examples/) for more informati
 
 Add the following to your `WORKSPACE` file to add this repository and its dependencies.
 
+<!-- BEGIN WORKSPACE SNIPPET -->
 ```python
-
 # Download and configure rules_swiftformat.
 
 http_archive(
@@ -78,6 +78,7 @@ load("@cgrindel_rules_swiftformat//swiftformat:load_package.bzl", "swiftformat_l
 
 swiftformat_load_package()
 ```
+<!-- END WORKSPACE SNIPPET -->
 
 ### 2. Update the `BUILD.bazel` at the root of your workspace
 

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -1,0 +1,29 @@
+load(
+    "@cgrindel_bazel_starlib//bzlrelease:defs.bzl",
+    "create_release",
+    "generate_release_notes",
+    "generate_workspace_snippet",
+    "update_readme",
+)
+
+# MARK: - Release
+
+generate_workspace_snippet(
+    name = "generate_workspace_snippet",
+    template = "workspace_snippet.tmpl",
+)
+
+generate_release_notes(
+    name = "generate_release_notes",
+    generate_workspace_snippet = ":generate_workspace_snippet",
+)
+
+update_readme(
+    name = "update_readme",
+    generate_workspace_snippet = ":generate_workspace_snippet",
+)
+
+create_release(
+    name = "create",
+    workflow_name = "Create Release",
+)

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
     "@cgrindel_bazel_starlib//bzlrelease:defs.bzl",
     "create_release",
@@ -27,3 +28,5 @@ create_release(
     name = "create",
     workflow_name = "Create Release",
 )
+
+bzlformat_pkg(name = "bzlformat")

--- a/release/workspace_snippet.tmpl
+++ b/release/workspace_snippet.tmpl
@@ -1,0 +1,44 @@
+# Download and configure rules_swiftformat.
+
+${http_archive_statement}
+
+load("@cgrindel_rules_swiftformat//swiftformat:deps.bzl", "swiftformat_rules_dependencies")
+
+swiftformat_rules_dependencies()
+
+# Configure the dependencies for rules_swiftformat
+
+load(
+    "@cgrindel_bazel_starlib//:deps.bzl",
+    "bazel_starlib_dependencies",
+)
+
+bazel_starlib_dependencies()
+
+load(
+    "@cgrindel_rules_spm//spm:deps.bzl",
+    "spm_rules_dependencies",
+)
+
+spm_rules_dependencies()
+
+load(
+    "@build_bazel_rules_swift//swift:repositories.bzl",
+    "swift_rules_dependencies",
+)
+
+swift_rules_dependencies()
+
+load(
+    "@build_bazel_rules_swift//swift:extras.bzl",
+    "swift_rules_extra_dependencies",
+)
+
+swift_rules_extra_dependencies()
+
+# We are using rules_spm to download and build SwiftFormat. The following will configure
+# rules_spm to do that.
+
+load("@cgrindel_rules_swiftformat//swiftformat:load_package.bzl", "swiftformat_load_package")
+
+swiftformat_load_package()


### PR DESCRIPTION
Closes #36.

- Implemented release workflow using `bzlrelease`.
- Renamed CI workflow and updated to use `cgrindel/gha_set_up_bazel`.