### PR TITLE
Upgrade `rules_bazel_integration_test` to use `bazel-contrib` release.

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,3 @@
 # Do not add the examples directories here. Execute
-# `bazel run @cgrindel_rules_bazel_integration_test//tools:update_deleted_packages` 
+# `bazel run @contrib_rules_bazel_integration_test//tools:update_deleted_packages` 
 # to update the deleted packages in the .bazelrc.

--- a/.bazelrc
+++ b/.bazelrc
@@ -2,7 +2,7 @@
 # Trick bazel into treating BUILD files under examples/* as being regular files
 # This lets us glob() up all the files inside the examples to make them inputs to tests
 # (Note, we cannot use `common --deleted_packages` because the bazel version command doesn't support it)
-# To update these lines, run `bazel run @cgrindel_rules_bazel_integration_test//tools:update_deleted_packages`.
+# To update these lines, run `bazel run @contrib_rules_bazel_integration_test//tools:update_deleted_packages`.
 build --deleted_packages=examples/exclude_files,examples/exclude_files/Sources/App,examples/exclude_files/Sources/Foo,examples/exclude_files/Tests/AppTests,examples/exclude_files/Tests/FooTests,examples/rules_swift_helpers,examples/rules_swift_helpers/Sources/App,examples/rules_swift_helpers/Sources/Foo,examples/rules_swift_helpers/Tests/AppTests,examples/rules_swift_helpers/Tests/FooTests,examples/simple,examples/simple/Foo
 query --deleted_packages=examples/exclude_files,examples/exclude_files/Sources/App,examples/exclude_files/Sources/Foo,examples/exclude_files/Tests/AppTests,examples/exclude_files/Tests/FooTests,examples/rules_swift_helpers,examples/rules_swift_helpers/Sources/App,examples/rules_swift_helpers/Sources/Foo,examples/rules_swift_helpers/Tests/AppTests,examples/rules_swift_helpers/Tests/FooTests,examples/simple,examples/simple/Foo
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,7 +9,7 @@ load(
     "updatesrc_update_all",
 )
 load(
-    "@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "integration_test_utils",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,11 +49,22 @@ buildifier_prebuilt_register_toolchains()
 
 # MARK: - Integration Testing
 
-load("@cgrindel_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "contrib_rules_bazel_integration_test",
+    sha256 = "ab9bbf776b5874f8a02f639fec2fbb3e3eefa4403cf861ae00d7c7e4d757f9ff",
+    strip_prefix = "rules_bazel_integration_test-0.6.2",
+    urls = [
+        "http://github.com/bazel-contrib/rules_bazel_integration_test/archive/v0.6.2.tar.gz",
+    ],
+)
+
+load("@contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 
 bazel_integration_test_rules_dependencies()
 
-load("@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
+load("@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
 
 bazel_binaries(versions = SUPPORTED_BAZEL_VERSIONS)

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
-    "@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "bazel_integration_test",
     "bazel_integration_tests",
     "default_test_runner",
@@ -52,7 +52,7 @@ sh_binary(
     testonly = True,
     srcs = ["change_update_all_test.sh"],
     data = [
-        "@cgrindel_rules_bazel_integration_test//tools:create_scratch_dir",
+        "@contrib_rules_bazel_integration_test//tools:create_scratch_dir",
     ],
     deps = [
         "@bazel_tools//tools/bash/runfiles",

--- a/examples/change_update_all_test.sh
+++ b/examples/change_update_all_test.sh
@@ -16,7 +16,7 @@ assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
-create_scratch_dir_sh_location=cgrindel_rules_bazel_integration_test/tools/create_scratch_dir.sh
+create_scratch_dir_sh_location=contrib_rules_bazel_integration_test/tools/create_scratch_dir.sh
 create_scratch_dir_sh="$(rlocation "${create_scratch_dir_sh_location}")" || \
   (echo >&2 "Failed to locate ${create_scratch_dir_sh_location}" && exit 1)
 

--- a/swiftformat/deps.bzl
+++ b/swiftformat/deps.bzl
@@ -34,13 +34,3 @@ def swiftformat_rules_dependencies():
             "http://github.com/cgrindel/rules_spm/archive/v0.7.0.tar.gz",
         ],
     )
-
-    maybe(
-        http_archive,
-        name = "cgrindel_rules_bazel_integration_test",
-        sha256 = "39071d2ec8e3be74c8c4a6c395247182b987cdb78d3a3955b39e343ece624982",
-        strip_prefix = "rules_bazel_integration_test-0.5.0",
-        urls = [
-            "http://github.com/cgrindel/rules_bazel_integration_test/archive/v0.5.0.tar.gz",
-        ],
-    )


### PR DESCRIPTION
Related to bazel-contrib/rules_bazel_integration_test#47.