### PR TITLE
feat: allow client to specify `sha256` values and generate an assets declaration

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,13 +2,13 @@ workspace(name = "cgrindel_rules_swiftformat")
 
 load(
     "//swiftformat:deps.bzl",
-    "swiftformat_register_toolchains",
+    "swiftformat_register_prebuilt_toolchains",
     "swiftformat_rules_dependencies",
 )
 
 swiftformat_rules_dependencies()
 
-swiftformat_register_toolchains(version = "0.51.10")
+swiftformat_register_prebuilt_toolchains(version = "0.51.10")
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,13 +2,10 @@ workspace(name = "cgrindel_rules_swiftformat")
 
 load(
     "//swiftformat:deps.bzl",
-    "swiftformat_register_prebuilt_toolchains",
     "swiftformat_rules_dependencies",
 )
 
 swiftformat_rules_dependencies()
-
-swiftformat_register_prebuilt_toolchains(version = "0.51.10")
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 

--- a/examples/exclude_files/WORKSPACE
+++ b/examples/exclude_files/WORKSPACE
@@ -7,13 +7,13 @@ local_repository(
 
 load(
     "@cgrindel_rules_swiftformat//swiftformat:deps.bzl",
-    "swiftformat_register_toolchains",
+    "swiftformat_register_prebuilt_toolchains",
     "swiftformat_rules_dependencies",
 )
 
 swiftformat_rules_dependencies()
 
-swiftformat_register_toolchains(version = "0.51.10")
+swiftformat_register_prebuilt_toolchains(version = "0.51.10")
 
 load(
     "@cgrindel_bazel_starlib//:deps.bzl",

--- a/examples/exclude_files/WORKSPACE
+++ b/examples/exclude_files/WORKSPACE
@@ -7,13 +7,10 @@ local_repository(
 
 load(
     "@cgrindel_rules_swiftformat//swiftformat:deps.bzl",
-    "swiftformat_register_prebuilt_toolchains",
     "swiftformat_rules_dependencies",
 )
 
 swiftformat_rules_dependencies()
-
-swiftformat_register_prebuilt_toolchains(version = "0.51.10")
 
 load(
     "@cgrindel_bazel_starlib//:deps.bzl",
@@ -35,3 +32,10 @@ load(
 )
 
 swift_rules_extra_dependencies()
+
+load(
+    "@cgrindel_rules_swiftformat//swiftformat:defs.bzl",
+    "swiftformat_register_prebuilt_toolchains",
+)
+
+swiftformat_register_prebuilt_toolchains()

--- a/examples/rules_swift_helpers/WORKSPACE
+++ b/examples/rules_swift_helpers/WORKSPACE
@@ -7,13 +7,13 @@ local_repository(
 
 load(
     "@cgrindel_rules_swiftformat//swiftformat:deps.bzl",
-    "swiftformat_register_toolchains",
+    "swiftformat_register_prebuilt_toolchains",
     "swiftformat_rules_dependencies",
 )
 
 swiftformat_rules_dependencies()
 
-swiftformat_register_toolchains(version = "0.51.10")
+swiftformat_register_prebuilt_toolchains(version = "0.51.10")
 
 load(
     "@cgrindel_bazel_starlib//:deps.bzl",

--- a/examples/rules_swift_helpers/WORKSPACE
+++ b/examples/rules_swift_helpers/WORKSPACE
@@ -7,13 +7,10 @@ local_repository(
 
 load(
     "@cgrindel_rules_swiftformat//swiftformat:deps.bzl",
-    "swiftformat_register_prebuilt_toolchains",
     "swiftformat_rules_dependencies",
 )
 
 swiftformat_rules_dependencies()
-
-swiftformat_register_prebuilt_toolchains(version = "0.51.10")
 
 load(
     "@cgrindel_bazel_starlib//:deps.bzl",
@@ -35,3 +32,10 @@ load(
 )
 
 swift_rules_extra_dependencies()
+
+load(
+    "@cgrindel_rules_swiftformat//swiftformat:defs.bzl",
+    "swiftformat_register_prebuilt_toolchains",
+)
+
+swiftformat_register_prebuilt_toolchains()

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -7,13 +7,14 @@ local_repository(
 
 load(
     "@cgrindel_rules_swiftformat//swiftformat:deps.bzl",
-    "swiftformat_register_prebuilt_toolchains",
     "swiftformat_rules_dependencies",
 )
 
 swiftformat_rules_dependencies()
 
-swiftformat_register_prebuilt_toolchains(version = "0.51.10")
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 load(
     "@cgrindel_bazel_starlib//:deps.bzl",
@@ -35,3 +36,10 @@ load(
 )
 
 swift_rules_extra_dependencies()
+
+load(
+    "@cgrindel_rules_swiftformat//swiftformat:defs.bzl",
+    "swiftformat_register_prebuilt_toolchains",
+)
+
+swiftformat_register_prebuilt_toolchains()

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -7,13 +7,13 @@ local_repository(
 
 load(
     "@cgrindel_rules_swiftformat//swiftformat:deps.bzl",
-    "swiftformat_register_toolchains",
+    "swiftformat_register_prebuilt_toolchains",
     "swiftformat_rules_dependencies",
 )
 
 swiftformat_rules_dependencies()
 
-swiftformat_register_toolchains(version = "0.51.10")
+swiftformat_register_prebuilt_toolchains(version = "0.51.10")
 
 load(
     "@cgrindel_bazel_starlib//:deps.bzl",

--- a/swiftformat/BUILD.bazel
+++ b/swiftformat/BUILD.bazel
@@ -19,6 +19,7 @@ bzl_library(
         "//swiftformat/internal:swiftformat_library",
         "//swiftformat/internal:swiftformat_pkg",
         "//swiftformat/internal:swiftformat_test",
+        "//swiftformat/toolchains:toolchain",
     ],
 )
 

--- a/swiftformat/BUILD.bazel
+++ b/swiftformat/BUILD.bazel
@@ -43,7 +43,6 @@ bzl_library(
     name = "deps",
     srcs = ["deps.bzl"],
     deps = [
-        "//swiftformat/toolchains:assets",
         "@bazel_tools//tools/build_defs/repo:http.bzl",
         "@bazel_tools//tools/build_defs/repo:utils.bzl",
     ],

--- a/swiftformat/defs.bzl
+++ b/swiftformat/defs.bzl
@@ -24,6 +24,13 @@ load(
     "//swiftformat/internal:swiftformat_test.bzl",
     _swiftformat_test = "swiftformat_test",
 )
+load(
+    "//swiftformat/toolchains:toolchain.bzl",
+    _swiftformat_register_prebuilt_toolchains = "swiftformat_register_prebuilt_toolchains",
+)
+
+# Toolchain Registration
+swiftformat_register_prebuilt_toolchains = _swiftformat_register_prebuilt_toolchains
 
 # Macros
 swiftformat_pkg = _swiftformat_pkg

--- a/swiftformat/deps.bzl
+++ b/swiftformat/deps.bzl
@@ -2,12 +2,6 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load(
-    "//swiftformat/toolchains:assets.bzl",
-    _swiftformat_register_prebuilt_toolchains = "swiftformat_register_prebuilt_toolchains",
-)
-
-swiftformat_register_prebuilt_toolchains = _swiftformat_register_prebuilt_toolchains
 
 def swiftformat_rules_dependencies():
     """Loads the dependencies for `rules_swiftformat`."""

--- a/swiftformat/deps.bzl
+++ b/swiftformat/deps.bzl
@@ -4,10 +4,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load(
     "//swiftformat/toolchains:assets.bzl",
-    _swiftformat_register_toolchains = "swiftformat_register_toolchains",
+    _swiftformat_register_prebuilt_toolchains = "swiftformat_register_prebuilt_toolchains",
 )
 
-swiftformat_register_toolchains = _swiftformat_register_toolchains
+swiftformat_register_prebuilt_toolchains = _swiftformat_register_prebuilt_toolchains
 
 def swiftformat_rules_dependencies():
     """Loads the dependencies for `rules_swiftformat`."""

--- a/swiftformat/toolchains/BUILD.bazel
+++ b/swiftformat/toolchains/BUILD.bazel
@@ -10,8 +10,8 @@ filegroup(
 )
 
 bzl_library(
-    name = "assets",
-    srcs = ["assets.bzl"],
+    name = "prebuilt_assets",
+    srcs = ["prebuilt_assets.bzl"],
     visibility = ["//visibility:public"],
     deps = [
         "@bazel_skylib//lib:types",
@@ -24,7 +24,7 @@ bzl_library(
     srcs = ["toolchain.bzl"],
     visibility = ["//visibility:public"],
     deps = [
-        ":assets",
+        ":prebuilt_assets",
         "@bazel_tools//tools/build_defs/repo:http.bzl",
         "@bazel_tools//tools/build_defs/repo:utils.bzl",
     ],

--- a/swiftformat/toolchains/BUILD.bazel
+++ b/swiftformat/toolchains/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
-load(":toolchain.bzl", "declare_swiftformat_toolchains")
 
 bzlformat_pkg(name = "bzlformat")
 
@@ -10,20 +9,23 @@ filegroup(
     visibility = ["//:__subpackages__"],
 )
 
-# Toolchain
-
-declare_swiftformat_toolchains()
-
 bzl_library(
     name = "assets",
     srcs = ["assets.bzl"],
     visibility = ["//visibility:public"],
-    deps = ["@bazel_tools//tools/build_defs/repo:http.bzl"],
+    deps = [
+        "@bazel_skylib//lib:types",
+        "@bazel_tools//tools/build_defs/repo:http.bzl",
+    ],
 )
 
 bzl_library(
     name = "toolchain",
     srcs = ["toolchain.bzl"],
     visibility = ["//visibility:public"],
-    deps = [":assets"],
+    deps = [
+        ":assets",
+        "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "@bazel_tools//tools/build_defs/repo:utils.bzl",
+    ],
 )

--- a/swiftformat/toolchains/assets.bzl
+++ b/swiftformat/toolchains/assets.bzl
@@ -1,99 +1,106 @@
 """Support downloading prebuilt SwiftFormat binaries."""
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_skylib//lib:types.bzl", "types")
 
-def _create(os, cpu, file, archive = None):
-    if archive == None:
-        archive = file + ".zip"
-    repo = "swiftformat_download_{}_{}".format(os, cpu)
-    swiftformat_toolchain_name = "download_{}_{}".format(os, cpu)
-    toolchain_name = swiftformat_toolchain_name + "_toolchain"
+_VALID_TOOLS = ["swiftformat"]
+
+def _create(
+        tool,
+        os,
+        cpu,
+        file,
+        urls,
+        sha256 = None,
+        repo = None,
+        executable_label = None,
+        swiftformat_toolchain_name = None,
+        toolchain_name = None):
+    """Create an asset.
+
+    Args:
+        tool: The name of the tool (e.g. swiftformat) as a `string`.
+        os: The operating system name as a `string`.
+        cpu: The cpu as a `string`.
+        file: The name of the executable in the archive as a `string`.
+        urls: A `list` of urls to download the archive file that contains the
+            executable.
+        sha256: Optional. The SHA256 value for the archive as a `string`.
+        repo: Optional. The name of the repository for the downloaded archive
+            as a `string`.
+        executable_label: Optional. The label for the executable as a `string`.
+        swiftformat_toolchain_name: Optional. The name for the
+            `swiftformat_toolchain` as a `string`.
+        toolchain_name: Optional. The name of the `toolchain` as a `string`.
+
+    Returns:
+        A `struct` representing a downloadable asset.
+    """
+    if tool not in _VALID_TOOLS:
+        fail("Invalid tool. tool: {}".format(tool))
+    if repo == None:
+        repo = "{tool}_download_{os}_{cpu}".format(
+            tool = tool,
+            os = os,
+            cpu = cpu,
+        )
+    if swiftformat_toolchain_name == None:
+        swiftformat_toolchain_name = repo
+    if toolchain_name == None:
+        toolchain_name = swiftformat_toolchain_name + "_toolchain"
+    if executable_label == None:
+        executable_label = "@{repo}//:executable".format(repo = repo)
     return struct(
+        tool = tool,
         os = os,
         cpu = cpu,
         file = file,
-        archive = archive,
+        urls = urls,
         repo = repo,
         swiftformat_toolchain_name = swiftformat_toolchain_name,
         toolchain_name = toolchain_name,
-        executable_label = "@{repo}//:executable".format(
-            repo = repo,
-        ),
+        executable_label = executable_label,
+        sha256 = sha256,
     )
-
-_ALL_ASSETS = [
-    _create(
-        os = "macos",
-        cpu = "x86_64",
-        file = "swiftformat",
-    ),
-    _create(
-        os = "macos",
-        cpu = "arm64",
-        file = "swiftformat",
-    ),
-    _create(
-        os = "linux",
-        cpu = "x86_64",
-        file = "swiftformat_linux",
-    ),
-]
-
-assets = struct(
-    create = _create,
-    all = _ALL_ASSETS,
-)
-
-# MARK: - Repository Rules
 
 _SWIFTFORMAT_DOWNLOAD_URL_TEMPLATE = """\
 https://github.com/nicklockwood/SwiftFormat/releases/download/{version}/{archive}\
 """
 
-def _urls(asset, version):
-    return [
-        _SWIFTFORMAT_DOWNLOAD_URL_TEMPLATE.format(
-            version = version,
-            archive = asset.archive,
-        ),
-    ]
+def _create_swiftformat(version, os, cpu, file, archive = None, sha256 = None):
+    if archive == None:
+        archive = file + ".zip"
+    return _create(
+        tool = "swiftformat",
+        os = os,
+        cpu = cpu,
+        file = file,
+        urls = [
+            _SWIFTFORMAT_DOWNLOAD_URL_TEMPLATE.format(
+                version = version,
+                archive = archive,
+            ),
+        ],
+        sha256 = sha256,
+    )
 
-# buildifier: disable=unnamed-macro
-def swiftformat_register_prebuilt_toolchains(version, register_toolchains = True):
-    """Register the toolchains for SwiftFormat.
+def _from_json(json_str):
+    """Returns an asset `struct` or a `list` of asset `struct` values as represented by the JSON `string`.
 
     Args:
-        version: The SwiftFormat version as a `string`.
-        register_toolchains: Optional. A `bool` that determines whether this
-            function should call `register_toolchains()`
-    """
-    repos = {}
-    for asset in _ALL_ASSETS:
-        repo = repos.get(asset.repo)
-        if repo != None:
-            continue
-        repos[asset.repo] = struct(
-            name = asset.repo,
-            urls = _urls(asset, version),
-            file = asset.file,
-        )
-    for repo in repos.values():
-        http_archive(
-            name = repo.name,
-            urls = repo.urls,
-            build_file_content = """\
-package(default_visibility = ["//visibility:public"])
+        json_str: A JSON `string` representing an asset or a list of assets.
 
-genrule(
-    name = "executable",
-    srcs = ["{file}"],
-    outs = ["swiftformat_exec"],
-    executable = True,
-    cmd = "cp $< $@ && chmod +x $@",
+    Returns:
+        An asset `struct` or a `list` of asset `struct` values.
+    """
+    result = json.decode(json_str)
+    if types.is_list(result):
+        return [_create(**a) for a in result]
+    elif types.is_dict(result):
+        return _create(**result)
+    fail("Unexpected result type decoding JSON string. %s" % (json_str))
+
+assets = struct(
+    create = _create,
+    create_swiftformat = _create_swiftformat,
+    from_json = _from_json,
 )
-""".format(file = repo.file),
-        )
-    if register_toolchains:
-        native.register_toolchains(
-            "@cgrindel_rules_swiftformat//swiftformat/toolchains:all",
-        )

--- a/swiftformat/toolchains/assets.bzl
+++ b/swiftformat/toolchains/assets.bzl
@@ -59,7 +59,7 @@ def _urls(asset, version):
     ]
 
 # buildifier: disable=unnamed-macro
-def swiftformat_register_toolchains(version, register_toolchains = True):
+def swiftformat_register_prebuilt_toolchains(version, register_toolchains = True):
     """Register the toolchains for SwiftFormat.
 
     Args:

--- a/swiftformat/toolchains/prebuilt_assets.bzl
+++ b/swiftformat/toolchains/prebuilt_assets.bzl
@@ -54,6 +54,18 @@ https://github.com/nicklockwood/SwiftFormat/releases/download/{version}/{archive
 """
 
 def _create_swiftformat(version, os, cpu, file, sha256 = None):
+    """Create an asset declaration for the swiftformat tool.
+
+    Args:
+        version: The version as a `string`.
+        os: The operating system name as a `string`.
+        cpu: The cpu as a `string`.
+        file: The name of the executable in the archive as a `string`.
+        sha256: Optional. The SHA256 value for the archive file as a `string`.
+
+    Returns:
+        An asset `struct` as returned by `prebuilt_assets.create()`.
+    """
     repo = "swiftformat_download_{os}_{cpu}".format(
         os = os,
         cpu = cpu,

--- a/swiftformat/toolchains/prebuilt_assets.bzl
+++ b/swiftformat/toolchains/prebuilt_assets.bzl
@@ -99,7 +99,7 @@ def _from_json(json_str):
         return _create(**result)
     fail("Unexpected result type decoding JSON string. %s" % (json_str))
 
-assets = struct(
+prebuilt_assets = struct(
     create = _create,
     create_swiftformat = _create_swiftformat,
     from_json = _from_json,

--- a/swiftformat/toolchains/prebuilt_assets.bzl
+++ b/swiftformat/toolchains/prebuilt_assets.bzl
@@ -2,32 +2,30 @@
 
 load("@bazel_skylib//lib:types.bzl", "types")
 
-_VALID_TOOLS = ["swiftformat"]
+# _VALID_TOOLS = ["swiftformat"]
 
 def _create(
-        tool,
         os,
         cpu,
         file,
         urls,
+        executable_label,
+        repo,
         sha256 = None,
-        repo = None,
-        executable_label = None,
         swiftformat_toolchain_name = None,
         toolchain_name = None):
     """Create an asset.
 
     Args:
-        tool: The name of the tool (e.g. swiftformat) as a `string`.
         os: The operating system name as a `string`.
         cpu: The cpu as a `string`.
         file: The name of the executable in the archive as a `string`.
         urls: A `list` of urls to download the archive file that contains the
             executable.
+        executable_label: The label for the executable as a `string`.
+        repo: The name of the repository for the downloaded archive as a
+            `string`.
         sha256: Optional. The SHA256 value for the archive as a `string`.
-        repo: Optional. The name of the repository for the downloaded archive
-            as a `string`.
-        executable_label: Optional. The label for the executable as a `string`.
         swiftformat_toolchain_name: Optional. The name for the
             `swiftformat_toolchain` as a `string`.
         toolchain_name: Optional. The name of the `toolchain` as a `string`.
@@ -35,22 +33,11 @@ def _create(
     Returns:
         A `struct` representing a downloadable asset.
     """
-    if tool not in _VALID_TOOLS:
-        fail("Invalid tool. tool: {}".format(tool))
-    if repo == None:
-        repo = "{tool}_download_{os}_{cpu}".format(
-            tool = tool,
-            os = os,
-            cpu = cpu,
-        )
     if swiftformat_toolchain_name == None:
         swiftformat_toolchain_name = repo
     if toolchain_name == None:
         toolchain_name = swiftformat_toolchain_name + "_toolchain"
-    if executable_label == None:
-        executable_label = "@{repo}//:executable".format(repo = repo)
     return struct(
-        tool = tool,
         os = os,
         cpu = cpu,
         file = file,
@@ -66,11 +53,13 @@ _SWIFTFORMAT_DOWNLOAD_URL_TEMPLATE = """\
 https://github.com/nicklockwood/SwiftFormat/releases/download/{version}/{archive}\
 """
 
-def _create_swiftformat(version, os, cpu, file, archive = None, sha256 = None):
-    if archive == None:
-        archive = file + ".zip"
+def _create_swiftformat(version, os, cpu, file, sha256 = None):
+    repo = "swiftformat_download_{os}_{cpu}".format(
+        os = os,
+        cpu = cpu,
+    )
+    archive = file + ".zip"
     return _create(
-        tool = "swiftformat",
         os = os,
         cpu = cpu,
         file = file,
@@ -80,6 +69,8 @@ def _create_swiftformat(version, os, cpu, file, archive = None, sha256 = None):
                 archive = archive,
             ),
         ],
+        executable_label = "@{repo}//:executable".format(repo = repo),
+        repo = repo,
         sha256 = sha256,
     )
 

--- a/swiftformat/toolchains/prebuilt_assets.bzl
+++ b/swiftformat/toolchains/prebuilt_assets.bzl
@@ -87,7 +87,8 @@ def _create_swiftformat(version, os, cpu, file, sha256 = None):
     )
 
 def _from_json(json_str):
-    """Returns an asset `struct` or a `list` of asset `struct` values as represented by the JSON `string`.
+    """Returns an asset `struct` or a `list` of asset `struct` values as \
+    represented by the JSON `string`.
 
     Args:
         json_str: A JSON `string` representing an asset or a list of assets.

--- a/swiftformat/toolchains/toolchain.bzl
+++ b/swiftformat/toolchains/toolchain.bzl
@@ -1,7 +1,7 @@
 """Define the toolchains for rules_swiftformat."""
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load(":assets.bzl", "assets")
+load(":prebuilt_assets.bzl", "prebuilt_assets")
 
 SwiftformatInfo = provider(
     doc = "Provider for Swiftformat toolchain.",
@@ -33,39 +33,39 @@ swiftformat_toolchain = rule(
     doc = "Define a toolchain for Swiftformat.",
 )
 
-DEFAULT_SWIFTFORMAT_VERSION = "0.51.10"
-
+# Update this list by running the following and copying the `assets` list values.
+# `bazel run //tools:generate_assets_declaration -- "0.51.11"`
 DEFAULT_ASSETS = [
-    assets.create_swiftformat(
-        version = DEFAULT_SWIFTFORMAT_VERSION,
-        sha256 = "",
+    prebuilt_assets.create_swiftformat(
+        version = "0.51.11",
         os = "macos",
         cpu = "x86_64",
         file = "swiftformat",
+        sha256 = "e565ebf6c54ee8e1ac83e4974edae34e002f86eda358a5838c0171f32f00ab20",
     ),
-    assets.create_swiftformat(
-        version = DEFAULT_SWIFTFORMAT_VERSION,
-        sha256 = "",
+    prebuilt_assets.create_swiftformat(
+        version = "0.51.11",
         os = "macos",
         cpu = "arm64",
         file = "swiftformat",
+        sha256 = "e565ebf6c54ee8e1ac83e4974edae34e002f86eda358a5838c0171f32f00ab20",
     ),
-    assets.create_swiftformat(
-        version = DEFAULT_SWIFTFORMAT_VERSION,
-        sha256 = "",
+    prebuilt_assets.create_swiftformat(
+        version = "0.51.11",
         os = "linux",
         cpu = "x86_64",
         file = "swiftformat_linux",
+        sha256 = "a49b79d97c234ccb5bcd2064ffec868e93e2eabf2d5de79974ca3802d8e389ec",
     ),
 ]
 
 def _swiftformat_toolchain_setup_impl(repository_ctx):
-    asset_list = assets.from_json(repository_ctx.attr.assets_json)
+    assets = prebuilt_assets.from_json(repository_ctx.attr.assets_json)
     content = """\
 load("@cgrindel_rules_swiftformat//swiftformat/toolchains:toolchain.bzl", "swiftformat_toolchain")
 
 """
-    for asset in asset_list:
+    for asset in assets:
         content += """\
 swiftformat_toolchain(
     name = "{swiftformat_toolchain_name}",
@@ -103,18 +103,18 @@ _swiftformat_toolchain_setup = repository_rule(
 
 def swiftformat_register_prebuilt_toolchains(
         name = "swiftformat_prebuilt_toolchains",
-        asset_list = DEFAULT_ASSETS,
+        assets = DEFAULT_ASSETS,
         register_toolchains = True):
     """Register the toolchains for SwiftFormat.
 
     Args:
         name: The name for the toolchains repository as a `string`.
-        asset_list: A `list` of tools to register.
+        assets: A `list` of tools to register.
         register_toolchains: Optional. A `bool` that determines whether this
             function should call `register_toolchains()`
     """
     toolchain_labels = []
-    for asset in asset_list:
+    for asset in assets:
         toolchain_label = "@{repo}//:{name}".format(
             repo = name,
             name = asset.toolchain_name,
@@ -138,7 +138,7 @@ genrule(
 
     _swiftformat_toolchain_setup(
         name = name,
-        assets_json = json.encode(asset_list),
+        assets_json = json.encode(assets),
     )
 
     if register_toolchains:

--- a/swiftformat/toolchains/toolchain.bzl
+++ b/swiftformat/toolchains/toolchain.bzl
@@ -1,5 +1,6 @@
 """Define the toolchains for rules_swiftformat."""
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load(":assets.bzl", "assets")
 
 SwiftformatInfo = provider(
@@ -32,22 +33,113 @@ swiftformat_toolchain = rule(
     doc = "Define a toolchain for Swiftformat.",
 )
 
-# buildifier: disable=unnamed-macro
-def declare_swiftformat_toolchains():
-    """Declare the SwiftFormat toolchain targets.
+DEFAULT_SWIFTFORMAT_VERSION = "0.51.10"
+
+DEFAULT_ASSETS = [
+    assets.create_swiftformat(
+        version = DEFAULT_SWIFTFORMAT_VERSION,
+        sha256 = "",
+        os = "macos",
+        cpu = "x86_64",
+        file = "swiftformat",
+    ),
+    assets.create_swiftformat(
+        version = DEFAULT_SWIFTFORMAT_VERSION,
+        sha256 = "",
+        os = "macos",
+        cpu = "arm64",
+        file = "swiftformat",
+    ),
+    assets.create_swiftformat(
+        version = DEFAULT_SWIFTFORMAT_VERSION,
+        sha256 = "",
+        os = "linux",
+        cpu = "x86_64",
+        file = "swiftformat_linux",
+    ),
+]
+
+def _swiftformat_toolchain_setup_impl(repository_ctx):
+    asset_list = assets.from_json(repository_ctx.attr.assets_json)
+    content = """\
+load("@cgrindel_rules_swiftformat//swiftformat/toolchains:toolchain.bzl", "swiftformat_toolchain")
+
+"""
+    for asset in asset_list:
+        content += """\
+swiftformat_toolchain(
+    name = "{swiftformat_toolchain_name}",
+    tool = "{executable_label}",
+)
+
+toolchain(
+    name = "{toolchain_name}",
+    exec_compatible_with = [
+        "@platforms//os:{os}",
+        "@platforms//cpu:{cpu}",
+    ],
+    toolchain = "{swiftformat_toolchain_name}",
+    toolchain_type = "@cgrindel_rules_swiftformat//swiftformat:toolchain",
+)
+""".format(
+            cpu = asset.cpu,
+            executable_label = asset.executable_label,
+            os = asset.os,
+            swiftformat_toolchain_name = asset.swiftformat_toolchain_name,
+            toolchain_name = asset.toolchain_name,
+        )
+    repository_ctx.file("BUILD.bazel", content)
+
+_swiftformat_toolchain_setup = repository_rule(
+    implementation = _swiftformat_toolchain_setup_impl,
+    attrs = {
+        "assets_json": attr.string(
+            doc = "The assets to download encoded as JSON.",
+            mandatory = True,
+        ),
+    },
+    doc = "Declares the toolchains for the provided assets.",
+)
+
+def swiftformat_register_prebuilt_toolchains(
+        name = "swiftformat_prebuilt_toolchains",
+        asset_list = DEFAULT_ASSETS,
+        register_toolchains = True):
+    """Register the toolchains for SwiftFormat.
+
+    Args:
+        name: The name for the toolchains repository as a `string`.
+        asset_list: A `list` of tools to register.
+        register_toolchains: Optional. A `bool` that determines whether this
+            function should call `register_toolchains()`
     """
-    for asset in assets.all:
-        swiftformat_toolchain(
-            name = asset.swiftformat_toolchain_name,
-            tool = asset.executable_label,
+    toolchain_labels = []
+    for asset in asset_list:
+        toolchain_label = "@{repo}//:{name}".format(
+            repo = name,
+            name = asset.toolchain_name,
+        )
+        toolchain_labels.append(toolchain_label)
+        http_archive(
+            name = asset.repo,
+            urls = asset.urls,
+            build_file_content = """\
+package(default_visibility = ["//visibility:public"])
+
+genrule(
+    name = "executable",
+    srcs = ["{file}"],
+    outs = ["swiftformat_exec"],
+    executable = True,
+    cmd = "cp $< $@ && chmod +x $@",
+)
+""".format(file = asset.file),
         )
 
-        native.toolchain(
-            name = asset.toolchain_name,
-            exec_compatible_with = [
-                "@platforms//os:{}".format(asset.os),
-                "@platforms//cpu:{}".format(asset.cpu),
-            ],
-            toolchain = asset.swiftformat_toolchain_name,
-            toolchain_type = "//swiftformat:toolchain",
-        )
+    _swiftformat_toolchain_setup(
+        name = name,
+        assets_json = json.encode(asset_list),
+    )
+
+    if register_toolchains:
+        native.register_toolchains(*toolchain_labels)

--- a/tests/toolchains_tests/BUILD.bazel
+++ b/tests/toolchains_tests/BUILD.bazel
@@ -1,0 +1,6 @@
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+load(":prebuilt_assets_tests.bzl", "prebuilt_assets_test_suite")
+
+bzlformat_pkg(name = "bzlformat")
+
+prebuilt_assets_test_suite()

--- a/tests/toolchains_tests/prebuilt_assets_tests.bzl
+++ b/tests/toolchains_tests/prebuilt_assets_tests.bzl
@@ -1,0 +1,103 @@
+"""Tests for `prebuilt_assets` module."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//swiftformat/toolchains:prebuilt_assets.bzl", "prebuilt_assets")
+
+def _create_test(ctx):
+    env = unittest.begin(ctx)
+
+    actual = prebuilt_assets.create(
+        os = "linux",
+        cpu = "x86_64",
+        file = "sometool_linux",
+        urls = ["https://somewhere.com"],
+        executable_label = "@sometool_download_linux_x86_64//:tool",
+        repo = "sometool_download_linux_x86_64",
+        sha256 = "XYZZY",
+    )
+    expected = struct(
+        os = "linux",
+        cpu = "x86_64",
+        file = "sometool_linux",
+        urls = ["https://somewhere.com"],
+        executable_label = "@sometool_download_linux_x86_64//:tool",
+        repo = "sometool_download_linux_x86_64",
+        sha256 = "XYZZY",
+        swiftformat_toolchain_name = "sometool_download_linux_x86_64",
+        toolchain_name = "sometool_download_linux_x86_64_toolchain",
+    )
+    asserts.equals(env, expected, actual)
+
+    return unittest.end(env)
+
+create_test = unittest.make(_create_test)
+
+def _create_swiftformat_test(ctx):
+    env = unittest.begin(ctx)
+
+    actual = prebuilt_assets.create_swiftformat(
+        version = "0.51.11",
+        os = "macos",
+        cpu = "arm64",
+        file = "swiftformat",
+        sha256 = "XYZZY",
+    )
+    expected = struct(
+        os = "macos",
+        cpu = "arm64",
+        file = "swiftformat",
+        sha256 = "XYZZY",
+        urls = [
+            "https://github.com/nicklockwood/SwiftFormat/releases/download/0.51.11/swiftformat.zip",
+        ],
+        executable_label = "@swiftformat_download_macos_arm64//:executable",
+        repo = "swiftformat_download_macos_arm64",
+        swiftformat_toolchain_name = "swiftformat_download_macos_arm64",
+        toolchain_name = "swiftformat_download_macos_arm64_toolchain",
+    )
+    asserts.equals(env, expected, actual)
+
+    return unittest.end(env)
+
+create_swiftformat_test = unittest.make(_create_swiftformat_test)
+
+def _from_json_test(ctx):
+    env = unittest.begin(ctx)
+
+    assets = [
+        prebuilt_assets.create_swiftformat(
+            version = "0.51.11",
+            os = "macos",
+            cpu = "x86_64",
+            file = "swiftformat",
+            sha256 = "e565ebf6c54ee8e1ac83e4974edae34e002f86eda358a5838c0171f32f00ab20",
+        ),
+        prebuilt_assets.create_swiftformat(
+            version = "0.51.11",
+            os = "macos",
+            cpu = "arm64",
+            file = "swiftformat",
+            sha256 = "e565ebf6c54ee8e1ac83e4974edae34e002f86eda358a5838c0171f32f00ab20",
+        ),
+        prebuilt_assets.create_swiftformat(
+            version = "0.51.11",
+            os = "linux",
+            cpu = "x86_64",
+            file = "swiftformat_linux",
+            sha256 = "a49b79d97c234ccb5bcd2064ffec868e93e2eabf2d5de79974ca3802d8e389ec",
+        ),
+    ]
+    actual = prebuilt_assets.from_json(json.encode(assets))
+    asserts.equals(env, assets, actual)
+
+    return unittest.end(env)
+
+from_json_test = unittest.make(_from_json_test)
+
+def prebuilt_assets_test_suite(name = "prebuilt_assets_tests"):
+    return unittest.suite(
+        name,
+        create_test,
+        create_swiftformat_test,
+        from_json_test,
+    )

--- a/tests/tools_tests/BUILD.bazel
+++ b/tests/tools_tests/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+
+bzlformat_pkg(name = "bzlformat")
+
+sh_test(
+    name = "generate_assets_declaration_test",
+    srcs = ["generate_assets_declaration_test.sh"],
+    data = [
+        "//tools:generate_assets_declaration",
+    ],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_starlib//shlib/lib:assertions",
+    ],
+)

--- a/tests/tools_tests/generate_assets_declaration_test.sh
+++ b/tests/tools_tests/generate_assets_declaration_test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -o nounset -o pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -o errexit
+# --- end runfiles.bash initialization v2 ---
+
+# MARK - Locate Deps
+
+assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
+assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+# shellcheck disable=SC1090
+source "${assertions_sh}"
+
+generate_assets_declaration_sh_location=cgrindel_rules_swiftformat/tools/generate_assets_declaration.sh
+generate_assets_declaration_sh="$(rlocation "${generate_assets_declaration_sh_location}")" || \
+  (echo >&2 "Failed to locate ${generate_assets_declaration_sh_location}" && exit 1)
+
+
+# MARK - Set Up a Workspace Directory
+
+# Bazel sh_binary targets expect BUILD_WORKSPACE_DIRECTORY to exist. Because
+# we are in a test, we need to fake it out.
+
+repo_dir="${PWD}/repo"
+rm -rf "${repo_dir}"
+mkdir -p "${repo_dir}"
+export "BUILD_WORKSPACE_DIRECTORY=${repo_dir}"
+
+# MARK - Test with Release Tag
+
+actual="$( "${generate_assets_declaration_sh}" "0.51.11" )"
+assert_match "version.*0.51.11" "${actual}"
+assert_match "os.*macos" "${actual}"
+assert_match "os.*linux" "${actual}"
+assert_match "cpu.*x86_64" "${actual}"
+assert_match "cpu.*arm64" "${actual}"
+assert_match "sha256.*e565ebf6c54ee8e1ac83e4974edae34e002f86eda358a5838c0171f32f00ab20" "${actual}"
+assert_match "sha256.*a49b79d97c234ccb5bcd2064ffec868e93e2eabf2d5de79974ca3802d8e389ec" "${actual}"

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+
+bzlformat_pkg(name = "bzlformat")
+
+sh_binary(
+    name = "generate_assets_declaration",
+    srcs = ["generate_assets_declaration.sh"],
+    visibility = ["//tests/tools_tests:__subpackages__"],
+)

--- a/tools/generate_assets_declaration.sh
+++ b/tools/generate_assets_declaration.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+
+readonly version="$1"
+
+download_and_calc_sha256() {
+  local url=$1
+  local bin
+  local sha256
+  bin="$(mktemp)"
+  curl --fail --silent -L "$url" -o "$bin"
+  sha256=$(shasum -a 256 "$bin" | cut -d ' ' -f 1)
+  rm -rf "${bin}"
+  echo "${sha256}"
+}
+
+generate_swiftformat_asset() {
+  local ver=$1
+  local os=$2
+  local cpu=$3
+  local file=$4
+  local sha256=$5
+  cat <<-EOF
+        prebuilt_assets.create_swiftformat(
+            version = "${ver}",
+            os = "${os}",
+            cpu = "${cpu}",
+            file = "${file}",
+            sha256 = "${sha256}",
+        ),
+EOF
+}
+
+swiftformat_base_url="https://github.com/nicklockwood/SwiftFormat/releases/download/${version}"
+assets=()
+
+swiftformat_macos_file="swiftformat"
+swiftformat_macos_url="${swiftformat_base_url}/${swiftformat_macos_file}.zip"
+swiftformat_macos_sha256="$(download_and_calc_sha256 "${swiftformat_macos_url}")"
+assets+=( "$(generate_swiftformat_asset "$version" macos x86_64 "$swiftformat_macos_file" "$swiftformat_macos_sha256")" )
+assets+=( "$(generate_swiftformat_asset "$version" macos arm64 "$swiftformat_macos_file" "$swiftformat_macos_sha256")" )
+
+swiftformat_linux_file="swiftformat_linux"
+swiftformat_linux_url="${swiftformat_base_url}/${swiftformat_linux_file}.zip"
+swiftformat_linux_sha256="$(download_and_calc_sha256 "${swiftformat_linux_url}")"
+assets+=( "$(generate_swiftformat_asset "$version" linux x86_64 "$swiftformat_linux_file" "$swiftformat_linux_sha256")" )
+
+cat <<-EOF
+load(
+    "@cgrindel_rules_swiftformat//swiftformat:defs.bzl", 
+    "swiftformat_register_prebuilt_toolchains", 
+    "prebuilt_assets",
+)
+
+swiftformat_register_prebuilt_toolchains(
+    assets = [
+$(printf '%s\n' "${assets[@]}")
+    ],
+)
+EOF


### PR DESCRIPTION
- Declare the toolchains in a separate repository.
- Rename `assets` to `prebuilt_assets`.
- Refactor `assets.create()` to be tool agnostic.

Closes #87.